### PR TITLE
set options.cwd as a string

### DIFF
--- a/lib/shell-runner.coffee
+++ b/lib/shell-runner.coffee
@@ -44,8 +44,8 @@ module.exports =
     newProcess: (testCommand) ->
       command = @currentShell
       args = ['-l', '-c', testCommand]
-      options = { cwd: @params.cwd }
-      console.log "ruby-test: Running test:", {command: command, args: args, cwd: @params.cwd()}
+      options = { cwd: @params.cwd() }
+      console.log "ruby-test: Running test:", {command: command, args: args, cwd: options.cwd}
       params = { command, args, options, @stdout, @stderr, @exit, @panel }
       outputCharacters = true
       process = new @processor params, outputCharacters


### PR DESCRIPTION
Trivial change to suppress TypeError about options.cwd being an anonymous function instead of a string.